### PR TITLE
Add FAQ documentation for students and deployers (fixes #50)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,37 @@
+
+# Frequently Asked Questions
+
+## For Students
+
+### Q: How do I access the lab system?
+A: Access the lab through the course portal. Contact your instructor if you don't have credentials.
+
+### Q: What are the system requirements?
+A: Check the README for detailed system requirements and installation instructions.
+
+### Q: How do I submit my work?
+A: Follow the submission guidelines in the README. Push your code to your branch and create a pull request.
+
+### Q: Where can I get help?
+A: Check the documentation in the README or open an issue on GitHub.
+
+### Q: What should I do if I encounter errors?
+A: Review the troubleshooting section in the docs or ask in an issue.
+
+## For Deployers
+
+### Q: How do I set up the lab system?
+A: Follow the installation steps in the README. Make sure all dependencies are installed.
+
+### Q: What are the deployment requirements?
+A: See the deployment guide in the documentation folder.
+
+### Q: How do I troubleshoot deployment issues?
+A: Check the logs and review common issues. Open an issue if you need help.
+
+### Q: How often should I update the system?
+A: Check for updates regularly and test them before deploying to production.
+
+### Q: What configurations do I need to set?
+A: Refer to the configuration documentation and examples in the repository.
+


### PR DESCRIPTION
Added comprehensive FAQ documentation with sections for:
- **Students**: System access, submission, help, troubleshooting
- **Deployers**: Setup, requirements, configuration, updates

This addresses the issue by providing FAQs for different user audiences as requested.